### PR TITLE
Add submodule for set-theory with initial commit reference

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "set-theory"]
+	path = set-theory
+	url = https://github.com/hypatia-tile/set-theory.git


### PR DESCRIPTION
This pull request adds a new Git submodule to the repository. The submodule, named `set-theory`, references an external repository and is now included as part of the project.

Submodule addition:

* Added a new submodule entry for `set-theory` in the `.gitmodules` file, pointing to `https://github.com/hypatia-tile/set-theory.git`.
* Included the initial commit reference for the `set-theory` subproject.